### PR TITLE
Fixes incorrect example

### DIFF
--- a/NJekyll/site/docs/deployment/index.md
+++ b/NJekyll/site/docs/deployment/index.md
@@ -106,7 +106,7 @@ For example, to deploy from "master" branch and only artifacts built for "x86" p
     - provider: Environment
       name: production
       on:
-        branch: release
+        branch: master
         platform: x86
 
 


### PR DESCRIPTION
Text in the paragraph noted the "master" branch but the code example was for the "release" branch.
