### PR TITLE
Added a note about mutually-exclusive badge parameters

### DIFF
--- a/NJekyll/site/docs/status-badges.md
+++ b/NJekyll/site/docs/status-badges.md
@@ -74,3 +74,5 @@ Optional parameters:
 Example: [https://ci.appveyor.com/api/projects/status/github/gruntjs/grunt?branch=master&svg=true](https://ci.appveyor.com/api/projects/status/github/gruntjs/grunt?branch=master&svg=true)
 
 ![Grunt status](https://ci.appveyor.com/api/projects/status/github/gruntjs/grunt?branch=master&svg=true)
+
+**Note**: The `retina` and `svg` parameters are mutually exclusive; only the first parameter specified is used.


### PR DESCRIPTION
Added a note to status-badges.md to clarify that the retina and svg parameters are mutually exclusive.
