### PR TITLE
Add a note about xunit.console.clr4 runner

### DIFF
--- a/NJekyll/site/docs/running-tests.md
+++ b/NJekyll/site/docs/running-tests.md
@@ -200,6 +200,9 @@ To run xUnit tests with real-time reporting use command:
 
 	xunit.console <assembly> /appveyor
 
+To run unit tests which target .NET 4.0 and later, use command:
+
+        xunit.console.clr4 <assembly> /appveyor
 
 <a id="mspec"></a>
 ### Machine.Specifications


### PR DESCRIPTION
Added a note about .NET 4.0+ runner for xUnit, otherwise it is very hard to investigate why your xUnit tests can not be performed.

```
xunit.console.clr4 <assembly> /appveyor
```
