### PR TITLE
Fix the build worker api link

### DIFF
--- a/NJekyll/site/docs/running-tests.md
+++ b/NJekyll/site/docs/running-tests.md
@@ -253,4 +253,4 @@ xunit.console .\path\to\test-assembly.dll /xml .\xunit-results.xml
 See also:
 
 * [Parallel testing](/docs/parallel-testing)
-* [Pushing test results from scripts using Build Agent API](/docs/build-agent-api#add-test)
+* [Pushing test results from scripts using Build Worker API](/docs/build-worker-api)

--- a/NJekyll/site/docs/running-tests.md
+++ b/NJekyll/site/docs/running-tests.md
@@ -253,4 +253,4 @@ xunit.console .\path\to\test-assembly.dll /xml .\xunit-results.xml
 See also:
 
 * [Parallel testing](/docs/parallel-testing)
-* [Pushing test results from scripts using Build Worker API](/docs/build-worker-api)
+* [Pushing test results from scripts using Build Worker API](docs/build-worker-api#add-tests)


### PR DESCRIPTION
<blockquote class="twitter-tweet" lang="en"><p><a href="https://twitter.com/kimsk">@kimsk</a> it should be <a href="http://t.co/MIGbvKiSrp">http://t.co/MIGbvKiSrp</a> - will fix that shortly.</p>&mdash; AppVeyor CI (@appveyor) <a href="https://twitter.com/appveyor/status/542423598657310721">December 9, 2014</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>