### PR TITLE
The actual tag name is not in the branch env var

### DIFF
--- a/NJekyll/site/docs/branches.md
+++ b/NJekyll/site/docs/branches.md
@@ -92,7 +92,7 @@ Unlike white- and blacklisting `branches` section here works like a selector, no
 
 By default AppVeyor starts a new build on any push to GitHub whether it's regular commit or a new tag. Repository tagging frequently used to trigger deployment.
 
-AppVeyor sets `APPVEYOR_REPO_TAG` environment variable to distinguish regular commits from tags - the value is `True` if tag was pushed; otherwise it's `False`. When it's `True` the name of tag is stored in `APPVEYOR_REPO_BRANCH`.
+AppVeyor sets `APPVEYOR_REPO_TAG` environment variable to distinguish regular commits from tags - the value is `True` if tag was pushed; otherwise it's `False`. When it's `True` the name of tag is stored in `APPVEYOR_REPO_TAG_NAME`.
 
 You can use `APPVEYOR_REPO_TAG` variable to trigger deployment on tag only, for example:
 


### PR DESCRIPTION
The APPVEYOR_REPO_BRANCH contains the branch being built, not the tag name.