### PR TITLE
Added Visual Studio 2013 Community...

### DIFF
--- a/NJekyll/site/docs/installed-software.md
+++ b/NJekyll/site/docs/installed-software.md
@@ -58,6 +58,7 @@ Below is the list of software pre-installed on Build Worker.
 * [Visual Studio Express 2013 for Windows Desktop with Update 3](http://www.microsoft.com/en-us/download/details.aspx?id=43733)
 * [Visual Studio Express 2013 for Windows with Update 3](http://www.microsoft.com/en-us/download/details.aspx?id=43729)
 * [Visual Studio Express 2013 for Web with Update 3](http://www.microsoft.com/en-us/download/details.aspx?id=43722 )
+* [Visual Studio Community 2013 with Update 4](http://www.visualstudio.com/products/visual-studio-community-vs)
 
 ## Languages, libraries, frameworks
 


### PR DESCRIPTION
Per <http://help.appveyor.com/discussions/questions/923-visual-studio-2013-update-4> this is installed on the instances now.  It's not clear if the express versions are removed... Can this list be updated?