### PR TITLE
Extend the Webhook example slightly

### DIFF
--- a/NJekyll/site/docs/notifications.md
+++ b/NJekyll/site/docs/notifications.md
@@ -255,7 +255,8 @@ Configuring webhooks in `appveyor.yml`:
           Authorization:
             secure: GhD+5xhLz/tkYY6AO3fcfQ==
         on_build_success: false
-        on_build_failure: True
+        on_build_failure: true
+        on_build_status_changed: true
 
 ### Webhook payload
 


### PR DESCRIPTION
This makes the Webhook example consistent with the one embedded in the [appveyor-yml reference](http://www.appveyor.com/docs/appveyor-yml) page.