### PR TITLE
Use single quote for %AppData%

### DIFF
--- a/NJekyll/site/docs/build-cache.md
+++ b/NJekyll/site/docs/build-cache.md
@@ -52,7 +52,7 @@ In `appveyor.yml`:
       - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
       - projectA\libs
       - node_modules                    # local npm modules
-      - %APPDATA%\npm-cache             # npm cache
+      - '%APPDATA%\npm-cache'             # npm cache
 
 ## Caching Chocolatey packages
 


### PR DESCRIPTION
As explained in https://help.appveyor.com/discussions/problems/2869-appdata-causes-error-parsing-appveyoryml-while-scanning-for-the-next-token-find-character-that-cannot-start-any-token#comment_37732584