### PR TITLE
Get nuget v3.2.0-rc to get fix of issue 1186

### DIFF
--- a/NJekyll/site/docs/nuget.md
+++ b/NJekyll/site/docs/nuget.md
@@ -159,15 +159,18 @@ Place [nuget-restore.cmd](https://github.com/appveyor/ci/blob/master/scripts/nug
 
 If solution file is located in the root of repo use this command to reliably restore nuget packages:
 
+    appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v3.2.0-rc/nuget.exe
     nuget-restore
 
 or
 
+    appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v3.2.0-rc/nuget.exe
     nuget-restore <path-to\solution.sln>
 
 If you don't want to pollute your repository with `nuget-restore.cmd` you can download it from GitHub during the build:
 
     before_build:
+      - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v3.2.0-rc/nuget.exe
       - appveyor DownloadFile https://raw.githubusercontent.com/appveyor/ci/master/scripts/nuget-restore.cmd
       - nuget-restore
 


### PR DESCRIPTION
http://docs.nuget.org/release-notes/nuget-3.2-rc
https://github.com/NuGet/Home/issues/1186

Due to issue 1186 which is fixed in 3.2-rc if nuget failed to restore a package it did not provide the correct error code. Alternatively if the build VMs could be updated to use 3.2 that would be even better.