### PR TITLE
Mention the use of Curl in download-file.md

### DIFF
--- a/NJekyll/site/docs/how-to/download-file.md
+++ b/NJekyll/site/docs/how-to/download-file.md
@@ -77,3 +77,17 @@ Command syntax:
 Example:
 
     appveyor DownloadFile http://www.myserver.com/packages/installer.msi
+
+## Curl
+
+[Curl](http://curl.haxx.se) (`curl.exe`) comes bundled with [Git](https://git-scm.com) and is therefore also available on the build workers.  Users on Unix-like operating systems may be more familiar with this command.
+
+Command syntax:
+
+    curl [-fsSL…] [-o <output-filename>] [-m <timeout-in-seconds>] <url>
+
+For scripting, using `-fsS` (or `-fsSL`) is recommended.  For more info on what the flags do, see the [curl manual](http://curl.haxx.se/docs/manpage.html).  Be aware that if neither `-o` nor `-O` are given, curl will dump the data to standard output.
+
+Example:
+
+    curl -fsS -o installer.msi http://www.myserver.com/packages/installer.msi


### PR DESCRIPTION
Since Curl is available on the build workers, this information would be useful for Unix users who may find Curl more familiar.