### PR TITLE
Add nuspec naming requirement into documentation

### DIFF
--- a/NJekyll/site/docs/nuget.md
+++ b/NJekyll/site/docs/nuget.md
@@ -42,7 +42,7 @@ The project feed contains all build artifact packages of type "NuGet package". I
 
 ### Automatic publishing of NuGet projects
 
-You can enable automatic publishing of NuGet packages during the build on the project settings **Build** tab. When it is enabled AppVeyor calls `nuget pack` for every project in the solution that has a `.nuspec` file in its root and then publishes NuGet package artifacts in both project and account feeds.
+You can enable automatic publishing of NuGet packages during the build on the project settings **Build** tab. When it is enabled AppVeyor calls `nuget pack` for every project in the solution that has a matching `.nuspec` file with the same name as the project in its root and then publishes NuGet package artifacts in both project and account feeds.
 
 To generate a `.nuspec` file for a project run the following command from within the *project* directory:
 


### PR DESCRIPTION
Updating documentation to resolve https://github.com/appveyor/ci/issues/739