### PR TITLE
Fix SQL Server connection string

### DIFF
--- a/NJekyll/site/docs/services-databases.md
+++ b/NJekyll/site/docs/services-databases.md
@@ -33,7 +33,7 @@ Instance name: `SQL2008R2SP2`
 
 Sample connection string:
 
-    Server=(local)\SQL2008R2SP2;Database=master;User ID=sa;Password=Password12!
+    Server=(local)\SQL2008R2SP2;Database=master;UID=sa;PWD=Password12!
 
 To start SQL Server 2008 Express in `appveyor.yml`:
 


### PR DESCRIPTION
Replace ADO 'User ID' and 'Password' keywords with correct SQL Server Native Client ODBC and OLE DB UID and PWD.

-----

Currently presented connection string gives

```
[Microsoft][SQL Server Native Client 11.0][SQL Server]Login failed for user ''.
[Microsoft][SQL Server Native Client 11.0]Invalid connection string attribute 
 ```

Reference [Using Connection String Keywords with SQL Server Native Client](https://msdn.microsoft.com/en-us/library/ms130822.aspx).

