### PR TITLE
Update path to agent

### DIFF
--- a/NJekyll/site/docs/deployment/agent.md
+++ b/NJekyll/site/docs/deployment/agent.md
@@ -40,7 +40,7 @@ The following is required on the server to run Deployment Agent:
 
 Run the following in PowerShell console:
 
-    (new-object net.webclient).DownloadFile('http://www.appveyor.com/downloads/AppveyorDeploymentAgent.msi', 'AppveyorDeploymentAgent.msi')
+    (new-object net.webclient).DownloadFile('http://www.appveyor.com/downloads/deployment-agent/latest/AppveyorDeploymentAgent.msi', 'AppveyorDeploymentAgent.msi')
     msiexec /i AppveyorDeploymentAgent.msi /quiet /qn /norestart /log install.log ENVIRONMENT_ACCESS_KEY=<your_access_key> DEPLOYMENT_GROUP=<your_deployment_group>
 
 > Replace `<your_access_key>` with your environment access key.


### PR DESCRIPTION
FYI - changing the location of the deployment agent broke our production Chef recipes that deploy AppVeyor. Please consider advance notices to customers in the future if you change any endpoints.