### PR TITLE
Typo Bitbucket

### DIFF
--- a/NJekyll/site/docs/environment-variables.md
+++ b/NJekyll/site/docs/environment-variables.md
@@ -22,7 +22,7 @@ Environment variables that are set by AppVeyor for every build:
 * `APPVEYOR_PULL_REQUEST_TITLE` - GitHub Pull Request title
 * `APPVEYOR_JOB_ID` - AppVeyor unique job ID;
 * `APPVEYOR_JOB_NAME` - job name;
-* `APPVEYOR_REPO_PROVIDER` - GitHub, BitBucket or Kiln;
+* `APPVEYOR_REPO_PROVIDER` - GitHub, Bitbucket or Kiln;
 * `APPVEYOR_REPO_SCM` - `git` or `mercurial`;
 * `APPVEYOR_REPO_NAME` - repository name in format `owner-name/repo-name`;
 * `APPVEYOR_REPO_BRANCH` - build branch. For Pull Request commits it is **base** branch PR is merging into;

--- a/NJekyll/site/docs/how-to/private-git-sub-modules.md
+++ b/NJekyll/site/docs/how-to/private-git-sub-modules.md
@@ -9,7 +9,7 @@ title: Building private GitHub repositories with sub-modules
 
 ## How AppVeyor is cloning private repos
 
-AppVeyor uses SSH to clone private Git repositories. When you add a project in AppVeyor a new RSA key-pair is generated which consists of private and public keys. Public key is deployed to a remote Git repository using GitHub (or BitBucket) API and private key is pushed to build worker during the build. For SSH protocol to work on Windows private key should be located in `%USERPROFILE%\.ssh\id_rsa` file.
+AppVeyor uses SSH to clone private Git repositories. When you add a project in AppVeyor a new RSA key-pair is generated which consists of private and public keys. Public key is deployed to a remote Git repository using GitHub (or Bitbucket) API and private key is pushed to build worker during the build. For SSH protocol to work on Windows private key should be located in `%USERPROFILE%\.ssh\id_rsa` file.
 
 ## The problem with private sub-modules
 

--- a/NJekyll/site/docs/how-to/repository-shallow-clone.md
+++ b/NJekyll/site/docs/how-to/repository-shallow-clone.md
@@ -6,7 +6,7 @@ title: Shallow clone of repositories
 # Shallow clone of repositories
 
 * [Setting depth of `git clone` command](#git-depth)
-* [Downloading repository via GitHub or BitBucket API](#download-via-api)
+* [Downloading repository via GitHub or Bitbucket API](#download-via-api)
 
 AppVeyor runs every build on a new VM which is getting decommissioned right after the build finishes. The state between consequent builds of the same project is not preserved and every time a new build starts AppVeyor clones entire repository and then checkouts a specific commit. This becomes a challenge for very large repositories or repositories with long history as it takes a significant time to do a clone.
 
@@ -18,16 +18,16 @@ The feature called "shallow clone" aims to improve the situation with large repo
 
 ## Setting depth of git clone command
 
-By default AppVeyor clones entire repository with all the history. You can limit the number of last commits you’d like to clone. This feature works for Git repositories hosted at GitHub and BitBucket. You can set clone depth on General tab of project settings or in `appveyor.yml`:
+By default AppVeyor clones entire repository with all the history. You can limit the number of last commits you’d like to clone. This feature works for Git repositories hosted at GitHub and Bitbucket. You can set clone depth on General tab of project settings or in `appveyor.yml`:
 
     clone_depth: <number>
 
 > Be aware that if you do a lot of commits producing queued builds and depth number is too small git checkout operation following git clone can fail because requested commit is not present in a cloned repository.
 
 
-## Downloading repository via GitHub or BitBucket API
+## Downloading repository via GitHub or Bitbucket API
 
-As title says this option is specific to GitHub and BitBucket only. It uses their respective REST API to download specific commit of the repository as zip archive and then unpacks it on build worker machine. This feature works for regular commits, branch commits and pull requests.
+As title says this option is specific to GitHub and Bitbucket only. It uses their respective REST API to download specific commit of the repository as zip archive and then unpacks it on build worker machine. This feature works for regular commits, branch commits and pull requests.
 
 You can enable this option through UI on General tab of project settings or in `appveyor.yml`:
 

--- a/NJekyll/site/docs/index.md
+++ b/NJekyll/site/docs/index.md
@@ -12,7 +12,7 @@ slug: docs
 
 ## Step 1 - Sign in with AppVeyor
 
-Use **GitHub** or **BitBucket** button to sign up with your existing developer account (OAuth) or create an AppVeyor account using your email and password.
+Use **GitHub** or **Bitbucket** button to sign up with your existing developer account (OAuth) or create an AppVeyor account using your email and password.
 
 
 

--- a/NJekyll/site/docs/nuget.md
+++ b/NJekyll/site/docs/nuget.md
@@ -21,7 +21,7 @@ All account feeds are password-protected. You can find the account feed URL and 
 
 You can use your AppVeyor account email/password to access password-protected NuGet feeds, although we recommend creating a separate user account just for these purposes (**Account -> Team**).
 
-> If you use the GitHub or BitBucket button to log in to AppVeyor you can reset your AppVeyor account password using the **Forgot password** link.
+> If you use the GitHub or Bitbucket button to log in to AppVeyor you can reset your AppVeyor account password using the **Forgot password** link.
 
 For publishing your own packages to your account feed use the command:
 
@@ -35,7 +35,7 @@ For publishing your own packages to your account feed use the command:
 
 ## Project NuGet feeds
 
-The project feed contains all build artifact packages of type "NuGet package". If it references a private GitHub or BitBucket repository the feed is password-protected; otherwise it is public access.
+The project feed contains all build artifact packages of type "NuGet package". If it references a private GitHub or Bitbucket repository the feed is password-protected; otherwise it is public access.
 
 
 

--- a/NJekyll/site/docs/status-badges.md
+++ b/NJekyll/site/docs/status-badges.md
@@ -55,7 +55,7 @@ For example:
 
 <image src="https://ci.appveyor.com/api/projects/status/32r7s2skrgm9ubva?svg=true&passingText=master%20-%20OK">
 
-## Badges for projects with public repositories on GitHub and BitBucket
+## Badges for projects with public repositories on GitHub and Bitbucket
 
 You can infer badge URL for **projects with public repositories**, well, provided there is only a single project with this repository in AppVeyor.
 

--- a/NJekyll/site/terms-of-service.html
+++ b/NJekyll/site/terms-of-service.html
@@ -256,7 +256,7 @@ title: Terms of Service
                             User Code resides in repository, which may be:
                             <ol>
                                 <li>self-hosted Git, Mercurial, TFVC or Subversion repository;</li>
-                                <li>hosted on GitHub, BitBucket, Visual Studio Online, Kiln; or</li>
+                                <li>hosted on GitHub, Bitbucket, Visual Studio Online, Kiln; or</li>
                                 <li>hosted on other services.</li>
                             </ol>
                         </li>


### PR DESCRIPTION
Replace "BitBucket" by "Bitbucket".

Reference: https://bitbucket.org/