### PR TITLE
Document bin folder location for MinGW-w64

### DIFF
--- a/NJekyll/site/docs/installed-software.md
+++ b/NJekyll/site/docs/installed-software.md
@@ -228,7 +228,8 @@ To switch to the latest io.js version using this PowerShell command:
 	* MinGW bin directory: `C:\MinGW\bin`
 	* MSYS root directory: `C:\MinGW\msys\1.0`
 * MinGW-w64:
-    * `C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0`
+	* MinGW root directory: `C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0`
+	* MinGW bin directory: `C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin`
 * Cygwin (`C:\cygwin`)
 * Cygwin 64 (`C:\cygwin64`)
 * MSYS2 (`C:\msys64`)


### PR DESCRIPTION
Documentation only mentions the installation prefix `C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0`, but it is unclear what is the actual structure of this.

Users either have to run `dir` during builds to discover or know details of MinGW-w64 distribution. This commit attempts to make it easier, for instance, to find which bin folder add to `PATH`.