### PR TITLE
The Powershell artifact download sample will fail with the Content-type set

### DIFF
--- a/src/docs/api/samples/download-artifacts-ps.md
+++ b/src/docs/api/samples/download-artifacts-ps.md
@@ -36,6 +36,7 @@ $localArtifactPath = "$downloadLocation\$artifactFileName"
 
 # download artifact
 # -OutFile - is local file name where artifact will be downloaded into
+# the Headers in this call should only contain the bearer token, and no Content-type, otherwise it will fail!
 Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts/$artifactFileName" `
--OutFile $localArtifactPath -Headers $headers
+-OutFile $localArtifactPath -Headers @{ "Authorization" = "Bearer $token" }
 ```


### PR DESCRIPTION
The last get to download the file will fail if the Content-type header is present.
The proposed change will only add the authorization header to the last request.