### PR TITLE
Remove branch condition from tag deployment

### DIFF
--- a/src/docs/deployment/index.md
+++ b/src/docs/deployment/index.md
@@ -151,7 +151,6 @@ You can use `APPVEYOR_REPO_TAG` variable to trigger deployment on tag only, for 
 - provider: Environment
   name: production
   on:
-    branch: master
     appveyor_repo_tag: true
 ```
 


### PR DESCRIPTION
This is mutually exclusive as we have tag as branch name in webhook for tags