### PR TITLE
Update Qt 5.6 version to reflect production

### DIFF
--- a/src/docs/installed-software.md
+++ b/src/docs/installed-software.md
@@ -270,7 +270,7 @@ Install-Product node '3'
         * msvc2015 32-bit: `C:\Qt\5.7\msvc2015`
         * msvc2013 64-bit: `C:\Qt\5.7\msvc2013_64`
         * msvc2013 32-bit: `C:\Qt\5.7\msvc2013`
-    * Qt 5.6.1: `C:\Qt\5.6`
+    * Qt 5.6.2: `C:\Qt\5.6`
         * MinGW 4.9.2 32 bit: `C:\Qt\5.6\mingw49_32`
         * msvc2015 64-bit: `C:\Qt\5.6\msvc2015_64`
         * msvc2015 32-bit: `C:\Qt\5.6\msvc2015`


### PR DESCRIPTION
**Note:** this is one of two pull-requests I'm submitting - both attempt to address the same problem, but each in a different way, so pick the one you prefer.

Specifically, the Qt 5.6 version stated at https://www.appveyor.com/docs/installed-software/#qt is out of date - it claims Qt 5.6.1, but the servers have 5.6.2 instead.

This pull request simply corrects the patch version number.

However, that page already omits the patch number for Qt version 5.3, 5.4 and 5.5.  So it might make better sense to instead simply drop the patch level version from the Qt 5.6 and 5.7 versions instead, which is what my other pull request (https://github.com/appveyor/website/pull/243) does instead.

Cheers.