### PR TITLE
Update download-artifacts-ps.md

### DIFF
--- a/src/docs/api/samples/download-artifacts-ps.md
+++ b/src/docs/api/samples/download-artifacts-ps.md
@@ -38,5 +38,5 @@ $localArtifactPath = "$downloadLocation\$artifactFileName"
 # -OutFile - is local file name where artifact will be downloaded into
 # the Headers in this call should only contain the bearer token, and no Content-type, otherwise it will fail!
 Invoke-RestMethod -Method Get -Uri "$apiUrl/buildjobs/$jobId/artifacts/$artifactFileName" `
--OutFile $localArtifactPath -Headers @{ "Authorization" = "Bearer $token" }
+-OutFile $localArtifactPath
 ```


### PR DESCRIPTION
The addition of the Authorization header makes this fail.  I tried the same thing with curl:

curl -L -H "Authorization: Bearer <token>" -o outfile https://ci.appveyor.com/api/...

With the Authorization header, it fails.  Once removed, it succeeds.