### PR TITLE
Try to fix up example code coverage badge

### DIFF
--- a/src/_posts/2017-03-17-codecov.md
+++ b/src/_posts/2017-03-17-codecov.md
@@ -113,7 +113,7 @@ after_test:
 
 There are various badges and graphs available. Click on your project in CodeCov, then "Settings" and "Badge" (eg `https://codecov.io/gh/YourGitHubUserName/YourRepositoryName/settings/badge`) to see what's available.
 
-Copy and paste a code snippet from this in to your README.md, such as this one [![Code Coverage](https://codecov.io/gh/ceddlyburge/codecov-on-appveyor/coverage.svg)](https://codecov.io/gh/ceddlyburge/codecov-on-appveyor).
+Copy and paste a code snippet from this in to your README.md, such as this one [![Code Coverage](https://codecov.io/gh/ceddlyburge/codecov-on-appveyor/coverage.svg)](https://codecov.io/gh/ceddlyburge/codecov-on-appveyor.svg).
 
 You can [look at my readme for example badges](https://github.com/ceddlyburge/codecov-on-appveyor/blob/master/README.md)
 


### PR DESCRIPTION
Hi Feodor, the "Code Coverage" status image under Add Coverage Graphics to the Repository section was working for me when running it locally, so its hard for me to know whether this change will work or not.

However, it looks like an error, so hopefully this fix will do it.

Cheers

Cedd