### PR TITLE
Example of caching NuGet v3 location

### DIFF
--- a/src/docs/appveyor-yml.md
+++ b/src/docs/appveyor-yml.md
@@ -137,7 +137,8 @@ cache:
   - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
   - projectA\libs
   - node_modules                    # local npm modules
-  - '%LocalAppData%\NuGet\Cache'
+  - '%LocalAppData%\NuGet\Cache'    # NuGet < v3
+  - '%LocalAppData%\NuGet\v3-cache  # NuGet v3
 
 # enable service required for build/tests
 services:


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/nuget/consume-packages/managing-the-nuget-cache, NuGet v3 has a different cache location.