### PR TITLE
selenium-testing.md: fix invalid option in example choco command

### DIFF
--- a/src/docs/how-to/selenium-testing.md
+++ b/src/docs/how-to/selenium-testing.md
@@ -26,7 +26,7 @@ Just add this line to `install` section of your `appveyor.yml` to remove the cur
 
 ```yaml
 install:
-  - choco install firefox -version 46.0.1
+  - choco install firefox --version 46.0.1
 ```
 
 In your tests you create `FirefoxDriver` as simply:


### PR DESCRIPTION
Running `choco install firefox -version 46.0.1` results in a warning:
```
Parsing -version resulted in error (converted to warning):
 Cannot bundle unregistered option '-e'.
```

According to [chocolatey docs](https://chocolatey.org/docs/commands-reference#how-to-pass-options-switches), the single dash is meant for one-character switches, which can be bundled. Hence `-version` is interpreted as 7 switches: `-v -e -r -s -i -o -n`. `--version` should be used instead.