### PR TITLE
Add information on PlatformToolset and DefaultPlatformToolset

### DIFF
--- a/src/docs/lang/cpp.md
+++ b/src/docs/lang/cpp.md
@@ -50,7 +50,7 @@ Visual Studio project select a toolchain based on the `<PlatformToolset />` elem
 
 The `PlatformToolset` value should be set after `Microsoft.Cpp.Default.props` properties are imported. An example is shown below.
 
-```
+```xml
 <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 <PropertyGroup Label="PlatformToolset">
   <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
@@ -59,7 +59,7 @@ The `PlatformToolset` value should be set after `Microsoft.Cpp.Default.props` pr
 
 If you are building with custom rules which may cause `DefaultPlatformToolset` to be undefined, then you can use the following to ensure `PlatformToolset` has a minumum value.
 
-```
+```xml
 <!-- Use DefaultPlatformToolset after Microsoft.Cpp.Default.props -->
 <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 

--- a/src/docs/lang/cpp.md
+++ b/src/docs/lang/cpp.md
@@ -43,3 +43,33 @@ required variables for
 [CL environment](https://msdn.microsoft.com/en-us/library/kezkeayy.aspx)
 and [LINK enviornment](https://msdn.microsoft.com/en-us/library/6y6t9esh.aspx)
 set properly for command-line builds.
+
+## PlatformToolset
+
+Visual Studio project select a toolchain based on the `<PlatformToolset />` element. To avoid potential problems project files should use the variable `DefaultPlatformToolset` as the value. Hardcoded values, like `v100` (Visual Studio 2010) and `v110` (Visual Studio 2012), can cause problems on some build worker images.
+
+The `PlatformToolset` value should be set after `Microsoft.Cpp.Default.props` properties are imported. An example is shown below.
+
+```
+<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+<PropertyGroup Label="PlatformToolset">
+  <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+</PropertyGroup>
+```
+
+If you are building with custom rules which may cause `DefaultPlatformToolset` to be undefined, then you can use the following to ensure `PlatformToolset` has a minumum value.
+
+```
+<!-- Use DefaultPlatformToolset after Microsoft.Cpp.Default.props -->
+<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+<!-- Set DefaultPlatformToolset to v100 (VS2010) if not defined -->
+<PropertyGroup Label="EmptyDefaultPlatformToolset">
+    <DefaultPlatformToolset Condition=" '$(DefaultPlatformToolset)' == '' ">v100</DefaultPlatformToolset>
+</PropertyGroup>
+
+<!-- Use DefaultPlatformToolset to set PlatformToolset -->
+<PropertyGroup Label="PlatformToolset">
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+</PropertyGroup>
+```


### PR DESCRIPTION
The PlatformToolset section is a feedback item based on experience when attempting to run an open source project under AppVeyor. This is one of the potential problems that AppVeyor users may encounter. Other issues may arise.