### PR TITLE
Update docs on scripts and interpreters

### DIFF
--- a/src/docs/build-configuration.md
+++ b/src/docs/build-configuration.md
@@ -184,6 +184,22 @@ environment:
   variable2: value
 ```
 
+### Interpreters and Scripts
+
+AppVeyor allows you to choose between Command scripting and PowerShell scripting. If you are using the Command interpreter and batch files then prefix your script with `cmd:` as shown below. Do not use `command:`.
+
+```yaml
+test_script:
+  - cmd: ECHO this is batch
+```
+
+If you are using the PowerShell then prefix your script with `ps:` as shown below. Do not use `powershell:`.
+
+```yaml
+test_script:
+  - ps: Write-Host "This is PowerShell"
+```
+
 ### Setting environment variables in build script
 
 CMD:
@@ -192,11 +208,15 @@ CMD:
 set MY_VARIABLE=value
 ```
 
+Once a variable is set for a batch file you access it by `%MY_VARIABLE%`.
+
 PowerShell:
 
 ```powershell
 $env:MY_VARIABLE="value"
 ```
+
+Once a PowerShell variable is set you access it by `$env:MY_VARIABLE`. Do not use PowerShell syntax of `$MY_VARIABLE`.
 
 ### Secure variables
 


### PR DESCRIPTION
Add section on scripts and interpreters. The page does not introduce them to the reader.

Add information on accessing variables in the two script engines. PowerShell is especially sneaky because it requires `$env:MY_VARIABLE`, and not `$MY_VARIABLE`. I wasted about 4 hours trying to figure out what was going wrong.