### PR TITLE
Mark LLVM as available on Visual Studio 2017

### DIFF
--- a/src/docs/build-environment.md
+++ b/src/docs/build-environment.md
@@ -590,11 +590,11 @@ You can use those images to unblock your builds while we are working together wi
     </tr>
     <tr>
         <td>LLVM 4.0.0 x64 (<code>C:\Program Files\LLVM\bin</code> in <code>PATH</code>)</td>
-        <td class="yes"></td><td class="yes"></td><td class="no"></td>
+        <td class="yes"></td><td class="yes"></td><td class="yes"></td>
     </tr>
     <tr>
         <td>LLVM 4.0.0 Compiler Infrastructure libraries (<code>C:\Libraries\llvm-4.0.0</code>)</td>
-        <td class="yes"></td><td class="yes"></td><td class="no"></td>
+        <td class="yes"></td><td class="yes"></td><td class="yes"></td>
     </tr>
     <!-- MinGW, MSYS, Cygwin -->
     <tr>


### PR DESCRIPTION
Apparently, LLVM/clang are available on the latest image:
```
> which clang
/c/Program Files/LLVM/bin/clang
> which clang++
/c/Program Files/LLVM/bin/clang++
> which clang-cl
/c/Program Files/LLVM/bin/clang-cl
> clang-cl -v
clang version 4.0.0 (tags/RELEASE_400/final)
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files\LLVM\bin
```

------

Current docs show no green dot in VS2017 column

https://www.appveyor.com/docs/build-environment/#llvm