### PR TITLE
Amend CodeCov upload script 

### DIFF
--- a/src/_posts/2016-11-22-create-signed-aligned-xamarin-apk.md
+++ b/src/_posts/2016-11-22-create-signed-aligned-xamarin-apk.md
@@ -4,7 +4,7 @@ title: Creating a Signed and ZipAligned APK (for Google Play) from Xamarin
 
 ## Introduction
 
-This is a guest post by [Cedd Burge](https://github.com/ceddlyburge), Software Developer Lead at [RES](http://resgroup.github.io/).
+This is a guest post by [Cedd Burge](https://github.com/ceddlyburge), Software Developer Lead at [RES](https://medium.com/res-software-team).
 
 This post is written from the point of view of someone (me) who is already proficient in C#, but was new to Xamarin, Mobile phone development, and AppVeyor.
 

--- a/src/_posts/2016-12-23-sonarqube.md
+++ b/src/_posts/2016-12-23-sonarqube.md
@@ -2,7 +2,7 @@
 title: SonarQube Analysis
 ---
 
-This is a guest post by [Cedd Burge](https://github.com/ceddlyburge), Software Developer Lead at [RES](http://resgroup.github.io/).
+This is a guest post by [Cedd Burge](https://github.com/ceddlyburge), Software Developer Lead at [RES](https://medium.com/res-software-team).
 
 SonarQube / SonarSource analyzes code, highlights quality issues and calculates metrics such as technical debt. More information is available on [SonarSource.com](https://www.sonarsource.com/).
 

--- a/src/_posts/2017-03-17-codecov.md
+++ b/src/_posts/2017-03-17-codecov.md
@@ -82,7 +82,7 @@ Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
 ```
 
 Then you can run the following in a Bash command line (You can use `Git Bash` on Windows). **YourUploadToken** is the CodeCov token that you took a note of earlier, or available on the project settings page on CodeCov (eg `https://codecov.io/gh/YourGitHubUserName/YourRepositoryName/settings`)
- 
+
 ```bash
 codecov.sh -f "coverage.xml" -t YourUploadToken
 ```

--- a/src/_posts/2017-03-17-codecov.md
+++ b/src/_posts/2017-03-17-codecov.md
@@ -2,7 +2,7 @@
 title: CodeCov Test Coverage Integration
 ---
 
-This is a guest post by [Cedd Burge](https://github.com/ceddlyburge), Software Developer Lead at [RES](http://resgroup.github.io/).
+This is a guest post by [Cedd Burge](https://github.com/ceddlyburge), Software Developer Lead at [RES](https://medium.com/res-software-team).
 
 CodeCov visualises code coverage and can enforce standards via GitHub and AppVeyor. More information is available on [CodeCov.io](https://codecov.io/).
 

--- a/src/_posts/2017-03-17-codecov.md
+++ b/src/_posts/2017-03-17-codecov.md
@@ -75,13 +75,16 @@ packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:"p
 
 ### Upload
 
-Download and install [Python 3.x](https://www.python.org/downloads/), make sure to tick the box to add Python to your path (or do so manually).
+Run the following on a PowerShell command line. This talks to CodeCov and downloads a bash script to upload the coverage.
 
-Run the following on the command line. You may need to close and reopen the console to pick up changes to the path. **YourUploadToken** is the CodeCov token that you took a note of earlier, or available on the project settings page on CodeCov (eg `https://codecov.io/gh/YourGitHubUserName/YourRepositoryName/settings`)
+```ps
+Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+```
 
-```batch
-pip install codecov
-codecov -f "coverage.xml" -t YourUploadToken
+Then you can run the following in a Bash command line (You can use `Git Bash` on Windows). **YourUploadToken** is the CodeCov token that you took a note of earlier, or available on the project settings page on CodeCov (eg `https://codecov.io/gh/YourGitHubUserName/YourRepositoryName/settings`)
+ 
+```bash
+codecov.sh -f "coverage.xml" -t YourUploadToken
 ```
 
 The output will show a url with the results (eg `https://codecov.io/gh/YourGitHubUserName/YourRepositoryName`)
@@ -104,9 +107,10 @@ build_script:
 test_script:
  - .\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"YourTestDll -noshadow" -output:"coverage.xml" -filter:"+[YourSUTNamepace*]* -[YourTestNamespace*]*"
 after_test:
- - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
- - pip install codecov
- - codecov -f "coverage.xml" -t YourUploadToken
+  - ps: |
+      $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
+      Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+      bash codecov.sh -f "coverage.xml" -t YourUploadToken
 ```
 
 ## Add Coverage Graphics to the Repository


### PR DESCRIPTION
This now relies on Bash and Powershell, which exist on the AppVeyor machine image and will be present on virtually all developer machines. This should make it easier to replicate the build locally, as there is no need to install python or the codedov python package.