### PR TITLE
Added section about caching vcpklg installed packages

### DIFF
--- a/src/docs/lang/cpp.md
+++ b/src/docs/lang/cpp.md
@@ -111,4 +111,10 @@ vcpkg install sqlite3:x64-windows
 cmake -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ...
 ```
 
+### Cache installed packages
+To enable faster (cached) rebuilds add the following to the cache section in the `appveyor.yml`:
+```bat
+cache: c:\tools\vcpkg\installed\
+```
+
 Read more about using Vcpkg in its [documentation](https://vcpkg.readthedocs.io).

--- a/src/docs/lang/cpp.md
+++ b/src/docs/lang/cpp.md
@@ -112,7 +112,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake ...
 ```
 
 ### Cache installed packages
+
 To enable faster (cached) rebuilds add the following to the cache section in the `appveyor.yml`:
+
 ```bat
 cache: c:\tools\vcpkg\installed\
 ```


### PR DESCRIPTION
Caching the installed folder allows for quicker rebuilds as packages don't need to be rebuilt when running vcpkg install.