### PR TITLE
fixed Miniconda path

### DIFF
--- a/src/docs/build-environment.md
+++ b/src/docs/build-environment.md
@@ -571,7 +571,7 @@ You can use those images to unblock your builds while we are working together wi
     <tr>
         <td>
             <ul>
-                <li>Miniconda2 4.3.27 (Python 2.7.13) - <code>C:\Miniconda</code></li>
+                <li>Miniconda2 4.3.27 (Python 2.7.13): <code>C:\Miniconda</code></li>
                 <li>Miniconda2 4.3.27 x64 (Python 2.7.13): <code>C:\Miniconda-x64</code></li>
                 <li>Miniconda3 3.16.0 (Python 3.4.3): <code>C:\Miniconda34</code></li>
                 <li>Miniconda3 3.16.0 x64 (Python 3.4.3): <code>C:\Miniconda34-x64</code></li>

--- a/src/docs/build-environment.md
+++ b/src/docs/build-environment.md
@@ -577,7 +577,7 @@ You can use those images to unblock your builds while we are working together wi
                 <li>Miniconda3 3.16.0 x64 (Python 3.4.3): <code>C:\Miniconda34-x64</code></li>
                 <li>Miniconda3 4.2.12 (Python 3.5.2): <code>C:\Miniconda35</code></li>
                 <li>Miniconda3 4.2.12 x64 (Python 3.5.2): <code>C:\Miniconda35-x64</code></li>
-                <li>Miniconda3 4.3.27 (Python 3.6.2): <code>C:\Miniconda36</code> or <code>C:\Miniconda</code></li>
+                <li>Miniconda3 4.3.27 (Python 3.6.2): <code>C:\Miniconda36</code> or <code>C:\Miniconda3</code></li>
                 <li>Miniconda3 4.3.27 x64 (Python 3.6.2): <code>C:\Miniconda36-x64</code> or <code>C:\Miniconda3-x64</code></li>
             </ul>
         </td>


### PR DESCRIPTION
Refer to ccbf2c87ad7a17f2979e3697cc787073543679ea.

The current version of docs is maping one path to two Minicondas:
>Miniconda2 4.3.27 (Python 2.7.13) - C:\Miniconda
Miniconda3 4.3.27 (Python 3.6.2): C:\Miniconda36 or C:\Miniconda

I haven't tested but assume from path of x64 version.