### PR TITLE
Add note about csproj/props xmlns not supported

### DIFF
--- a/src/docs/build-configuration.md
+++ b/src/docs/build-configuration.md
@@ -164,6 +164,7 @@ dotnet_csproj:
 ```
 
 **Note** that specific attribute like `PackageVersion` should exist in `.csproj` file to be patched.
+**Note** that the xmlns must not be defined or else the file won't be processed.
 
 You can use environment variables substitution in file name and version formats, for example:
 


### PR DESCRIPTION
Patching .csproj and .props/other similar doesn't support files with xmlns defined. Note may save some people a headache.

See https://github.com/appveyor/ci/issues/1750#issuecomment-356366858