### PR TITLE
Add commitMessageExtended to the webhook payload

### DIFF
--- a/src/docs/notifications.md
+++ b/src/docs/notifications.md
@@ -454,6 +454,7 @@ When webhook notification triggers AppVeyor makes POST request to the webhook UR
       "commitAuthorEmail":"john@smith.com",
       "commitDate":"2014-04-14 1:54 AM",
       "commitMessage":"Some changes to appveyor.yml",
+      "commitMessageExtended":"The rest of the commit message after the first line",
       "committerName":"John Smith",
       "committerEmail":"john@smith.com",
       "isPullRequest":true,


### PR DESCRIPTION
As mentioned in https://github.com/appveyor/ci/issues/2165 I'm seeing a `commitMessageExtended` value in my deployment payloads. I haven't checked normal build payloads so this update might not be 100% accurate.

There's also `environment`, `build`, and `buildJob` sections missing but I'm not sure if they're part of all payloads so I've left that out for now.