### PR TITLE
Clarify branches/except syntax

### DIFF
--- a/src/docs/branches.md
+++ b/src/docs/branches.md
@@ -34,9 +34,10 @@ branches:
 To specify the list of branches that must be ignored:
 
 ```yaml
-except:
-  - /dev.*/     # You can use Regular expression to match multiple branch name(s)
-  - playground
+branches:
+  except:
+    - /dev.*/     # You can use Regular expression to match multiple branch name(s)
+    - playground
 ```
 
 `gh-pages` branch is always excluded unless explicitly added in "only" list.


### PR DESCRIPTION
The previous text made it look like 'except' was a top-level keyword. It's not, at least not according to the appveyor.yml reference.