### PR TITLE
Update PowerShell Core version available Ubuntu image from 6.0.1 to 6.0.2

### DIFF
--- a/src/docs/getting-started-with-appveyor-for-linux.md
+++ b/src/docs/getting-started-with-appveyor-for-linux.md
@@ -425,7 +425,7 @@ The following software is pre-installed on `Ubuntu` image:
     * Nodejs v9.5.0
     * NVM
 * PowerShell
-    * PowerShell Core 6.0.1
+    * PowerShell Core 6.0.2
 * .NET Core
     * .NET Core Runtime 2.0.0
     * .NET Core Runtime 2.0.3


### PR DESCRIPTION
See [here](https://ci.appveyor.com/project/PowerShell/psscriptanalyzer/build/1.0.2405/job/hw222xh15xswspit) for a build that shows that PowerShell Core has already been updated to version 6.0.2.
I don't know why GitHub shows a diff for the localstack line, which I did not touch, that must be a bug in GitHub (I edited via the GitHub web UI)