### PR TITLE
Added warning to: Deploying to AWS Page

### DIFF
--- a/src/docs/deployment/amazon-elastic-beanstalk.md
+++ b/src/docs/deployment/amazon-elastic-beanstalk.md
@@ -54,3 +54,5 @@ deploy:
   on:
     branch: main # deploy from master branch only
 ```
+
+**Note**: Do not publish an appveyor.yml with AWS credentials in a public repository.


### PR DESCRIPTION
Just a small little warning to help dissuade people from publishing things they shouldn't in public repositories. Especially since said users, who naively do, could potentially wrongfully blame the directions that led them to that point.