### PR TITLE
Fixed bug in documentation example

### DIFF
--- a/src/docs/branches.md
+++ b/src/docs/branches.md
@@ -215,6 +215,7 @@ notifications:
   ...
 
 for:
+-
   branches:
     only:
       - master


### PR DESCRIPTION
Running this code fails with:

```
Error parsing appveyor.yml: 'for' must be a sequence. (Line: 7, Column: 3)
```

Fix is to add an `-` to make it a sequence.