### PR TITLE
environment-variables: fix APPVEYOR_REPO_PROVIDER value for GitLab and GitHub

### DIFF
--- a/src/docs/environment-variables.md
+++ b/src/docs/environment-variables.md
@@ -27,7 +27,7 @@ Environment variables that are set by AppVeyor for every build:
 * `APPVEYOR_JOB_ID` - AppVeyor unique job ID
 * `APPVEYOR_JOB_NAME` - job name
 * `APPVEYOR_JOB_NUMBER` - job number, i.g. 1, 2, etc.
-* `APPVEYOR_REPO_PROVIDER` - `github`, `bitbucket`, `kiln`, `vso` or `gitlab`
+* `APPVEYOR_REPO_PROVIDER` - `gitHub`, `bitbucket`, `kiln`, `vso` or `gitLab`
 * `APPVEYOR_REPO_SCM` - `git` or `mercurial`
 * `APPVEYOR_REPO_NAME` - repository name in format `owner-name/repo-name`
 * `APPVEYOR_REPO_BRANCH` - build branch. For Pull Request commits it is **base** branch PR is merging into


### PR DESCRIPTION
They were listed as `gitlab`/`github`, but in reality they are `gitLab`/`gitHub` (with an uppercase `L`/`H`) respectively.

Possibly `bitbucket` is also affected, but I haven't tested it.