### PR TITLE
build-environment.md: wrangle rotated text inside table fixes #485

### DIFF
--- a/src/assets/css/pages/installed-software.css
+++ b/src/assets/css/pages/installed-software.css
@@ -24,14 +24,14 @@ table.software-list td.no {
 }
 
 table.software-list th.rotate {
-    height: 140px;
+    height: 145px;
     white-space: nowrap;
 }
 
 table.software-list th.rotate > span {
     display: block;
-    padding: 0 5px;
-    transform: translate(0, 51px) rotate(270deg);
+    padding: 5px 0 5px;
+    transform: translate(0, 52px) rotate(270deg);
     width: 30px;
 }
 


### PR DESCRIPTION
Before and after
![table](https://user-images.githubusercontent.com/31389848/41816131-ae24247e-7774-11e8-8a2e-8a974d3b859f.gif)

This works fine under Opera 53 (stable) Firefox 66.0.2 Chrome  67 this gives better results multi-browser with variant resolutions from 1080p up to UHD 2560x1440p.

bare with me :)

Edit: There we go. updated PR I haven't updated gif but it works more or less the same in the 3 browsers, will do more testting in meanwhile, see if I can sideload these fixes in the MS's browsers.
