### PR TITLE
fix outdated link to "Download Azure account publishing profile"

### DIFF
--- a/src/_posts/2014-03-25-continuous-delivery-of-windows-azure-cloud-services-with-appveyor-ci.md
+++ b/src/_posts/2014-03-25-continuous-delivery-of-windows-azure-cloud-services-with-appveyor-ci.md
@@ -70,7 +70,7 @@ The form requires 3 prerequisites:
 
 ## Subscription details
 
-[Download Azure account publishing profile](https://manage.windowsazure.com/publishsettings/Index?client=vs&amp;SchemaVersion=1.0) and open it in text editor. Copy subscription ID and Base64 encoded subscription certificate.
+[Download Azure account publishing profile](http://go.microsoft.com/fwlink/?LinkID=294709) and open it in text editor. Copy subscription ID and Base64 encoded subscription certificate.
 
 ![Certificate](/assets/img/posts/azure-cs-ci/certificate.png)
 


### PR DESCRIPTION
as suggested here https://help.appveyor.com/discussions/problems/15494-azure-cloud-service-deployment-failure