### PR TITLE
Note to update curl

### DIFF
--- a/src/docs/api/index.md
+++ b/src/docs/api/index.md
@@ -77,3 +77,5 @@ The following command uses `curl` to get the list of roles from authenticated ac
 export APPVEYOR_TOKEN="<your-api-token>"
 curl -H "Authorization: Bearer $APPVEYOR_TOKEN" -H "Content-Type: application/json" https://ci.appveyor.com/api/roles
 ```
+
+**Note.** If you plan to download artifacts with curl you should update curl up to 7.58.0. Otherwise curl wont be able to download artifacts due to CVE-2018-1000007.


### PR DESCRIPTION
Downloading artifacts with curl was discussed [here](https://help.appveyor.com/discussions/problems/13969-cant-use-curl-to-download-artifacts) and [here] (https://help.appveyor.com/discussions/questions/19858-accessing-build-artifacts-from-one-project-in-another).
Also, there was a couple workaround suggested.