### PR TITLE
Update services-databases.md

### DIFF
--- a/src/docs/services-databases.md
+++ b/src/docs/services-databases.md
@@ -32,12 +32,12 @@ Also please note that all MS SQL servers use the same default port 1433. Therefo
     .SYNOPSIS
         Set all installed instances of SQL server to dynamic ports
 #>
-Get-ChildItem -Path 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\' | 
-    Where-Object { 
-        $_.Name -imatch 'MSSQL[_\d]+\.SQL.*' 
+Get-ChildItem -Path 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\' |
+    Where-Object {
+        $_.Name -imatch 'MSSQL[_\d]+\.SQL.*'
     } |
     ForEach-Object {
-        
+
         Write-Host "Setting $((Get-ItemProperty $_.PSPath).'(default)') to dynamic ports"
         Set-ItemProperty (Join-Path $_.PSPath 'mssqlserver\supersocketnetlib\tcp\ipall') -Name TcpDynamicPorts -Value '0'
         Set-ItemProperty (Join-Path $_.PSPath 'mssqlserver\supersocketnetlib\tcp\ipall') -Name TcpPort -Value ([string]::Empty)

--- a/src/docs/services-databases.md
+++ b/src/docs/services-databases.md
@@ -25,12 +25,23 @@ AppVeyor has most popular services and database engines pre-installed on all bui
 
 By default, their corresponding Windows services are stopped to reduce build machine boot time. On the **Environment** tab of project settings or in `appveyor.yml` you can configure which services must be started after the build machine has booted.
 
-Also please note that all MS SQL servers use the same default port 1433. Therefore please start and stop them sequentially to avoid port conflicts. To allow all SQL Server instances to be started simultaneously, please run [this script](https://gist.github.com/FeodorFitsner/a7eba7f44f9becacd3abddca27974e93) at `init` stage.
+Also please note that all MS SQL servers use the same default port 1433. Therefore please start and stop them sequentially to avoid port conflicts. To allow all SQL Server instances to be started simultaneously, please run the following script at `init` stage which will enumerate all currently available instances setting them to use dynamic ports, as the instances available on a build worker may change over time.
 
-Alternatively, run [this script](https://gist.github.com/fireflycons/58dfde9c2fab7de2f4e97668938baebe) which enumerates all currently installed instances, as the instances available on a build worker may change. It can be invoked in the init script thus
-```yaml
-init:
-  -ps: "[Net.ServicePointManager]::SecurityProtocol = 'tls12, tls11, tls, ssl3'; iex ((New-Object Net.WebClient).DownloadString('https://gist.github.com/fireflycons/58dfde9c2fab7de2f4e97668938baebe/raw'))"
+```powershell
+<#
+    .SYNOPSIS
+        Set all installed instances of SQL server to dynamic ports
+#>
+Get-ChildItem -Path 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\' | 
+    Where-Object { 
+        $_.Name -imatch 'MSSQL[_\d]+\.SQL.*' 
+    } |
+    ForEach-Object {
+        
+        Write-Host "Setting $((Get-ItemProperty $_.PSPath).'(default)') to dynamic ports"
+        Set-ItemProperty (Join-Path $_.PSPath 'mssqlserver\supersocketnetlib\tcp\ipall') -Name TcpDynamicPorts -Value '0'
+        Set-ItemProperty (Join-Path $_.PSPath 'mssqlserver\supersocketnetlib\tcp\ipall') -Name TcpPort -Value ([string]::Empty)
+    }
 ```
 
 ## SQL Server 2008

--- a/src/docs/services-databases.md
+++ b/src/docs/services-databases.md
@@ -27,6 +27,12 @@ By default, their corresponding Windows services are stopped to reduce build mac
 
 Also please note that all MS SQL servers use the same default port 1433. Therefore please start and stop them sequentially to avoid port conflicts. To allow all SQL Server instances to be started simultaneously, please run [this script](https://gist.github.com/FeodorFitsner/a7eba7f44f9becacd3abddca27974e93) at `init` stage.
 
+Alternatively, run [this script](https://gist.github.com/fireflycons/58dfde9c2fab7de2f4e97668938baebe) which enumerates all currently installed instances, as the instances available on a build worker may change. It can be invoked in the init script thus
+```yaml
+init:
+  -ps: "[Net.ServicePointManager]::SecurityProtocol = 'tls12, tls11, tls, ssl3'; iex ((New-Object Net.WebClient).DownloadString('https://gist.github.com/fireflycons/58dfde9c2fab7de2f4e97668938baebe/raw'))"
+```
+
 ## SQL Server 2008
 
 The latest version of **SQL Server 2008 Express R2 SP2 with Advanced Services** is available on AppVeyor build servers. This is a full install with Database Engine, Replication, Full-Text Search, Reporting Services and Management Studio Express enabled.


### PR DESCRIPTION
I propose a replacement for the script to set SQL instances to use dynamic ports. This script enumerates the registry to find currently installed instances and sets them to dynamic ports. I did this as I noted that the workers I'm getting have only 2014, 2016 and 2017 - which will eventually change, so a dynamic solution future-proofs it.
Example here: https://ci.appveyor.com/project/fireflycons/invoke-sqlexecute