### PR TITLE
Add description about Deployments on Pull Requests

### DIFF
--- a/src/docs/deployment/index.md
+++ b/src/docs/deployment/index.md
@@ -131,6 +131,9 @@ You can use standard and custom environment variables in provider settings, for 
 you can set a remote FTP folder as `$(appveyor_build_version)\artifacts` where `$(appveyor_build_version)`
 will be replaced with the current build version.
 
+## Pull Requests
+
+Deployments, `before_deploy` and `after_deploy` scripts are disabled by default on Pull Requests. Deployments on Pull Requests are only available for private repositories.
 
 ## Conditional deployment
 


### PR DESCRIPTION
Currently basically no documents mentioned Deployments are disabled on Pull Requests. The only related description is on the [Build configuretion](https://www.appveyor.com/docs/build-configuration/#appveyoryml-and-ui-coexistence) page:

> Those settings are in projects settings General tab. They are:
>
> - ...
> - Enable deployments in Pull Requests (available for private repos)
> - ...