### PR TITLE
Add example of for ubuntu image

### DIFF
--- a/src/docs/how-to/private-git-sub-modules.md
+++ b/src/docs/how-to/private-git-sub-modules.md
@@ -106,6 +106,21 @@ install:
   - git submodule update --init --recursive
 ```
 
+> Alternatively for `image: ubuntu`:
+
+```yaml
+image: ubuntu
+
+environment:
+  priv_key:
+    secure: <encryped-value>
+
+install:
+  - echo "-----BEGIN RSA PRIVATE KEY-----" > $HOME/.ssh/id_rsa
+  - echo "${priv_key}" | tr " " "\n" >> $HOME/.ssh/id_rsa
+  - echo "-----END RSA PRIVATE KEY-----" >> $HOME/.ssh/id_rsa
+  - git submodule update --init --recursive
+```
 
 ## Security considerations
 


### PR DESCRIPTION
This is a working example of creating a private ssh key for private git submodules on ubuntu image.

Note: The escaped new line in `ps` example is not needed in `sh` example because `echo` already puts new lines in.