### PR TITLE
ssh-to-build-worker.md: Additional tip for ubuntu

### DIFF
--- a/src/docs/how-to/ssh-to-build-worker.md
+++ b/src/docs/how-to/ssh-to-build-worker.md
@@ -43,6 +43,8 @@ on_finish:
   - sh: curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -
 ```
 
+Alternatively, you can add `sh: sleep 60m` to postpone finishing a script so that you have more time to investigate with `ssh`.
+
 SSH session is limited by overall build time (60 min).
 
 ## Generating SSH key


### PR DESCRIPTION
Sometimes a worker terminates an ssh connection early even with `sh: export APPVEYOR_SSH_BLOCK=true` because the `enable-ssh.sh` script already ran.

I useful solution I came up with was to add `sh: sleep 60m`.  I can kill the `sleep` process from inside my ssh session. Or I can manually cancel the build from the web ui.