### PR TITLE
Replace confusing logic statement with consistent explanation

### DIFF
--- a/src/docs/how-to/filtering-commits.md
+++ b/src/docs/how-to/filtering-commits.md
@@ -97,7 +97,7 @@ only_commits:
 
 ### Skip commits
 
-`skip_commits.files` allows skipping AppVeyor build if **all of the files** modified in push's **head commit** match *any* of the file matching rules (`AND` logic applied to multiple values):
+`skip_commits.files` allows skipping AppVeyor build if **all of the files** modified in push's **head commit** match **any** of the file matching rules:
 
 ```yaml
 skip_commits:
@@ -124,7 +124,7 @@ For the same set of rules commit modifying `docs/index.md` and `site/views/index
 
 ### Include commits
 
-`only_commits.files` allows starting a new AppVeyor build if only **some of the files** modified in push's **head commit** match their respective rules (`OR` logic applied to multiple values):
+`only_commits.files` allows starting a new AppVeyor build if **any file** modified in the push's **head commit** matches **any** of the file matching rules:
 
 For example `appveyor.yml` contains these rules:
 
@@ -135,7 +135,7 @@ only_commits:
     - Project-B/
 ```
 
-which means the build will be started only if one of the modified files was inside either `Project-A` or `Project-B` folder.
+Which means the build will be started only if one of the modified files was inside either the `Project-A` or `Project-B` folder.
 
 
 ### File matching rules
@@ -149,10 +149,10 @@ which means the build will be started only if one of the modified files was insi
 
 Notes:
 
-* both `\` and `/` slashes are allowed.
-* surround value with single quotes if starts from `*`, e.g. `'*.txt'`
+* both `\` and `/` slashes are allowed as directory separators.
+* surround a value with single quotes if it starts with a `*`, e.g. `'*.txt'`
 
-The following example triggers new build for changes in `src\ProjectA` folder only:
+The following example triggers a new build for changes in the `src\ProjectA` folder only:
 
 ```yaml
 only_commits:

--- a/src/docs/how-to/filtering-commits.md
+++ b/src/docs/how-to/filtering-commits.md
@@ -97,17 +97,7 @@ only_commits:
 
 ### Skip commits
 
-`skip_commits.files` allows skipping AppVeyor build if **all of the files** modified in push's **head commit** match **any** of the file matching rules:
-
-```yaml
-skip_commits:
-  files:
-    - dir/*
-    - dir/*.md
-    - full/path.txt
-    - another/dir/here/
-    - '**/*.html'
-```
+`skip_commits.files` allows skipping AppVeyor build if **all of the files** modified in push's **head commit** match **any** of the file matching rules.
 
 For example, if `appveyor.yml` contains the following rules:
 
@@ -118,9 +108,9 @@ skip_commits:
     - '**/*.html'
 ```
 
-and push commit modified two files: `docs/index.md` and `project-A/mysolution.sln` the build will be started as there is no rule matching `project-A/mysolution.sln`.
+and the pushed commit modified two files: `docs/index.md` and `project-A/mysolution.sln`, the build will be started. As there is no rule matching `project-A/mysolution.sln`.
 
-For the same set of rules commit modifying `docs/index.md` and `site/views/index.html` files won't start a build as both files match their respective rules.
+For the same set of rules a commit modifying `docs/index.md` and `site/views/index.html` won't start a build. As both files match their respective rules.
 
 ### Include commits
 


### PR DESCRIPTION
AND and OR logic difference applies to the different files.
The matching rules always use OR logic.

It would be possible to mention this difference in the logic statement, but that results in even more text.
Using the same sentence and accentuation style seems to be clearer.

\+ added a few articles
\+ Removed the first example. It does not add anything. Contains unnecessary rules (1st covers 2nd). And increases the distance to the section explaining the rules format.