### PR TITLE
Replace incorrect example

### DIFF
--- a/src/docs/notifications.md
+++ b/src/docs/notifications.md
@@ -125,24 +125,12 @@ notifications:
     to:
       - user1@email.com
       - user2@email.com
-    subject: 'Build {{status}}'                  # optional
+      - '{{commitAuthorEmail}}' # template variable, send email to the author of the commit
+    subject: 'Build {{status}}' # optional
     message: "{{template_variable_1}}, {{template_variable_2}}, ..."    # optional
     on_build_success: true|false
     on_build_failure: true|false
     on_build_status_changed: true|false
-{% endraw %}
-```
-
-Note that you can use template variables for message recipient. For example, this configuration will send email to failed commit author:
-
-```yaml
-{% raw %}
-notifications:
-  - provider: Email
-  to:
-  - '{{commitAuthorEmail}}'
-  ...
-  on_build_failure: true
 {% endraw %}
 ```
 

--- a/src/docs/notifications.md
+++ b/src/docs/notifications.md
@@ -126,6 +126,7 @@ notifications:
       - user1@email.com
       - user2@email.com
       - '{{commitAuthorEmail}}' # template variable, send email to the author of the commit
+      - '{{committerEmail}}'    # template variable, send email to the commiter (can be different for merges)
     subject: 'Build {{status}}' # optional
     message: "{{template_variable_1}}, {{template_variable_2}}, ..."    # optional
     on_build_success: true|false


### PR DESCRIPTION
The example uses inconsistent formatting and confuses.
`on_build_failure: true` is not the way to send an email on failure.
This option is `true` by default and *only* sending on failure requires setting `on_build_success: false`.

The `{{commitAuthorEmail}}` from this example can be added to the general example.

edit:
Added: `{{committerEmail}}`