### PR TITLE
Add advise to allow trigger builds on tags when using branches:only:

### DIFF
--- a/src/docs/branches.md
+++ b/src/docs/branches.md
@@ -44,6 +44,16 @@ branches:
 
 **Regular expressions** should be surrounded by `/`, otherwise Appveyor will do simple case insensitive string comparison.
 
+Despite the option name, `only` and `except` is applied to tag names too, so the above example using `only` would cause tags not trigger the build. For example to enable builds for a tag version scheme like `v1.0.0` you would need:
+
+```yaml
+branches:
+  only:
+    - master
+    - production
+    - /v\d*\.\d*\.\d*/
+```
+
 ## Conditional build configuration
 
 If you use [git flow](http://nvie.com/posts/a-successful-git-branching-model/) you may want to have a different build configuration (e.g. deploying to a different environment) in a feature branch. Changing `appveyor.yml` in a feature branch becomes an issue when you merge it into master overriding `appveyor.yml` and breaking master builds.


### PR DESCRIPTION
As commented in https://help.appveyor.com/discussions/problems/3483-github-tag-push-doesnt-trigger-build#comment_38384095
and recently tested in https://github.com/jneira/dhall-haskell/commit/f5d44d036b2d009beb2b0c0d6a4ef6a708f9d968