### PR TITLE
Fix styling of "Github" to "GitHub"

### DIFF
--- a/src/docs/build-configuration.md
+++ b/src/docs/build-configuration.md
@@ -105,7 +105,7 @@ After that place URL to YAML file to **Custom configuration .yml file name** set
 
 ### Generic Git repositories and YAML
 
-Appveyor attempts to acquire appveyor.yml (or custom YAML name) from the repository before starting the build. This happens on central servers (not build workers) before any git clone happens. At that moment AppVeyor only needs the content of that one configuration file and so a full clone would be too expensive on central servers which are scheduling thousands of builds. Generic git does not have an option to check out an individual file, therefore we are using the APIs of source control providers who support this directly (like "Get contents" from Github).
+Appveyor attempts to acquire appveyor.yml (or custom YAML name) from the repository before starting the build. This happens on central servers (not build workers) before any git clone happens. At that moment AppVeyor only needs the content of that one configuration file and so a full clone would be too expensive on central servers which are scheduling thousands of builds. Generic git does not have an option to check out an individual file, therefore we are using the APIs of source control providers who support this directly (like "Get contents" from GitHub).
 At the moment those supported are: GitLab, VSTS, Kiln, Stash (BitBucket Server) and GitHub Enterprise. If you are using any other git source control provider, you will need to use [Alternative YAML file location](#alternative-yaml-file-location) described above.
 
 ### YAML format notes

--- a/src/terms-of-service.html
+++ b/src/terms-of-service.html
@@ -37,7 +37,7 @@ description: Terms of Service
                         <li>“<strong>End User License Agreement</strong>” means AppVeyor’s End User License Agreement located at <a href="https://www.appveyor.com/eula">www.appveyor.com/eula</a>;</li>
                         <li>“<strong>Free Plan</strong>” has such meaning ascribed to it in Section 6.3;</li>
                         <li>“<strong>General Site Information</strong>” has such meaning ascribed to it in Section 4.1;</li>
-                        <li>“<strong>Github Plan</strong>” means a Subscription Plan offered through the GitHub Marketplace at <a href="https://github.com/marketplace/appveyor">https://github.com/marketplace/appveyor</a>;</li>
+                        <li>“<strong>GitHub Plan</strong>” means a Subscription Plan offered through the GitHub Marketplace at <a href="https://github.com/marketplace/appveyor">https://github.com/marketplace/appveyor</a>;</li>
                         <li>“<strong>Host Agent</strong>” means the downloadable program created by AppVeyor for managing processes, containers and VMs on a server in a Private Build Cloud.</li>
                         <li>“<strong>Post</strong>” means the act of uploading, posting, emailing, transmitting or otherwise making available Content through the Community Support or otherwise;</li>
                         <li>“<strong>Personal Information</strong>” means information about an identifiable individual, and includes such things as gender, age, ethnicity and financial information, health information, consumer preference information, user profiles and identification numbers;</li>


### PR DESCRIPTION
Just a typo fix to make the styling of "GitHub" consistent.