### PR TITLE
Set correct casing for `Configuration` environement variable

### DIFF
--- a/src/docs/environment-variables.md
+++ b/src/docs/environment-variables.md
@@ -44,7 +44,7 @@ Environment variables that are set by AppVeyor for every build:
 * `APPVEYOR_RE_BUILD` (`True` or undefined) - build started by "Re-build commit/PR" button of from the same API
 * `APPVEYOR_RE_RUN_INCOMPLETE` (`True` or undefined) - build job started by "Re-run incomplete" button of from the same API
 * `PLATFORM` - platform name set on Build tab of project settings (or through `platform` parameter in `appveyor.yml`)
-* `CONFIGURATION` - configuration name set on Build tab of project settings (or through `configuration` parameter in `appveyor.yml`)
+* `Configuration` - configuration name set on Build tab of project settings (or through `configuration` parameter in `appveyor.yml`)
 
 ## Tweak environment variables
 


### PR DESCRIPTION
The configuration name is set in the `Configuration` environment variable instead of `CONFIGURATION`. This doesn't matter for cmd or Powershell because they are case-insensitive but if you're trying to access it from MSYS2's Bash, it won't work because of the difference in casing.