### PR TITLE
Fix request_timeout typo in webhook.md

### DIFF
--- a/src/docs/deployment/webhook.md
+++ b/src/docs/deployment/webhook.md
@@ -49,7 +49,7 @@ Webhook payload body will have the following format:
 
 * **URL** (`url`) - webhook URL.
 * **"Authorization" header** (`authorization`) - optional `authorization` header added to the webhook request.
-* **Request timeout** (`authorization`) - optional POST request timeout in minutes. Default is 1 minute.
+* **Request timeout** (`request_timeout`) - optional POST request timeout in minutes. Default is 1 minute.
 
 Configuring in `appveyor.yml`:
 


### PR DESCRIPTION
I just noticed this small typo in the documentation, most likely a copy-paste mistake. Thanks for your work on AppVeyor!