### PR TITLE
Add -NoNewline option to Add-Content

### DIFF
--- a/src/docs/how-to/git-push.md
+++ b/src/docs/how-to/git-push.md
@@ -111,7 +111,7 @@ environment:
 
 on_success:
   - git config --global credential.helper store
-  - ps: Add-Content "$HOME\.git-credentials" "https://$($env:access_token):x-oauth-basic@github.com`n"
+  - ps: Add-Content -Path "$HOME\.git-credentials" -Value "https://$($env:access_token):x-oauth-basic@github.com`n" -NoNewline
   - git config --global user.email "Your email"
   - git config --global user.name "Your Name"
   - git commit ...


### PR DESCRIPTION
I have noticed that the extra newline that `Add-Content` adds to `.git-credentials` started making problems with git in the `Visual Studio 2019` image, probably because git changed in response to [CVE-2020-11008](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11008).