### PR TITLE
Adding a link to the API token page

### DIFF
--- a/src/docs/api/index.md
+++ b/src/docs/api/index.md
@@ -18,7 +18,7 @@ Samples:
 
 ## Authentication
 
-AppVeyor uses bearer token authentication. Token can be found on **API token** page under your AppVeyor account.
+AppVeyor uses bearer token authentication. Token can be found on [API token page](https://ci.appveyor.com/api-keys) under your AppVeyor account.
 
 Token must be set in `Authorization` header of every request to AppVeyor REST API:
 


### PR DESCRIPTION
Adding a link to the API token page, as requested: https://help.appveyor.com/discussions/questions/49620-where-is-the-api-token-page-under-the-appveyor-account