### PR TITLE
Remove `os` from `allowed_failures` conditions

### DIFF
--- a/src/docs/build-configuration.md
+++ b/src/docs/build-configuration.md
@@ -522,7 +522,7 @@ matrix:
     - <condition>: <value>
 ```
 
-`<condition>` can be `os`, `image`, `configuration`, `platform`, `test_category` or the name of environment variable.
+`<condition>` can be `image`, `configuration`, `platform`, `test_category` or the name of environment variable.
 
 For example, to allow job failing on Node.js 0.11 ([see Node.js instructions](/docs/lang/nodejs-iojs/)):
 


### PR DESCRIPTION
My experiments with `allow_failures` seem to be that `os` condition doesn't exist. Of course, this PR would require some verification.