### PR TITLE
Add MinGW 8.1.0 info for Qt

### DIFF
--- a/src/docs/windows-images-software.md
+++ b/src/docs/windows-images-software.md
@@ -1090,6 +1090,7 @@ title: Software pre-installed on Windows build VMs
             <ul>
             <li>Qt tools:
                 <ul>
+                <li>MinGW 8.1.0: <code>C:\Qt\Tools\mingw810_32</code></li>
                 <li>MinGW 7.3.0: <code>C:\Qt\Tools\mingw730_32</code></li>
                 <li>MinGW 5.3.0: <code>C:\Qt\Tools\mingw530_32</code></li>
                 <li>MinGW 4.9.2: <code>C:\Qt\Tools\mingw492_32</code></li>
@@ -1097,7 +1098,7 @@ title: Software pre-installed on Windows build VMs
             </li>
             </ul>
         </td>
-        <td class="yes"></td><td class="yes"></td><td class="yes"></td><td class="no"></td>
+        <td class="yes"></td><td class="yes"></td><td class="yes"></td><td class="yes"></td>
     </tr>
     <!-- Tools -->
     <tr>


### PR DESCRIPTION
According to the actual image, `mingw810_32` is available under VS 2019 image, so I added it here.

ps. I'm not sure if it actually also available under other images, please double check if possible. And maybe consider also listing MinGW 64 path (e.g. `C:\Qt\Tools\mingw810_64`)?