### PR TITLE
Correct documentation to include msvs 2019

### DIFF
--- a/src/docs/lang/cpp.md
+++ b/src/docs/lang/cpp.md
@@ -25,6 +25,20 @@ Build configured with makefiles or any scripts directly invoking compiler execut
 
 Run the following in the `appveyor.yml`:
 
+### Visual Studio 2019
+
+* For 32-bit target
+
+    ```bat
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
+    ```
+
+* For 64-bit target
+
+    ```bat
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+    ```
+
 ### Visual Studio 2017
 
 * For 32-bit target


### PR DESCRIPTION
This proposal adds in a section for msvs 2019, detailing the path to vsvars*.bat between 32bit and 64bit.

Recommended to accept due to the GUI and .yml accepting MSVS 2019.

I release any copyright to the maintainers of this repo to do whatever they wish.

Sorry about the branch name in advance, I used github to submit the minor changes.