### PR TITLE
change keys format if needed

### DIFF
--- a/src/docs/how-to/private-git-sub-modules.md
+++ b/src/docs/how-to/private-git-sub-modules.md
@@ -87,6 +87,8 @@ Set-Content c:\users\appveyor\.ssh\id_rsa $fileContent
 git submodule -q update --init --recursive
 ```
 
+💡 change the `RSA PRIVATE KEY` to `OPENSSH PRIVATE KEY` if your ssh gives you the ssh format keys.
+
 ### appveyor.yml
 
 Copy the contents of private key to clipboard as shown above and open "Encrypt configuration data" page in AppVeyor (**Account** &rarr; **Encrypt YAML**). Encrypt the value of clipboard using that page.


### PR DESCRIPTION
ssh-kengen -t generates ssh format keys on windows:
``ssh
-----BEGIN OPENSSH PRIVATE KEY-----
keyss.....
-----END OPENSSH PRIVATE KEY-----
```
the powers shell script should change accordingly