### PR TITLE
Testing with Python: Use `py` and add Python 3.8

### DIFF
--- a/src/docs/lang/python.md
+++ b/src/docs/lang/python.md
@@ -23,8 +23,11 @@ Several Python versions are already preinstalled:
 Add an `appveyor.yml` file to your repository root:
 
 ```yaml
-# appveyor.yml
+# appveyor.yml - https://www.appveyor.com/docs/lang/python
 ---
+image:
+  - Visual Studio 2019
+
 environment:
   matrix:
   # - TOXENV: py27  # https://devguide.python.org/devcycle/#end-of-life-branches

--- a/src/docs/lang/python.md
+++ b/src/docs/lang/python.md
@@ -33,7 +33,7 @@ environment:
   - TOXENV: py37
   - TOXENV: py38
   # - TOXENV: py39    # Not yet present in Appveyor image
-  # - TOXENV: py310    # Not yet present in Appveyor image
+  # - TOXENV: py310   # Not yet present in Appveyor image
 
 build: off
 

--- a/src/docs/lang/python.md
+++ b/src/docs/lang/python.md
@@ -32,14 +32,14 @@ environment:
   - TOXENV: py36    # https://devguide.python.org/#status-of-python-branches
   - TOXENV: py37
   - TOXENV: py38
-  # - TOXENV: py39    # Not yet present in Appveyor Windows image
-  # - TOXENV: py310   # Not yet present in Appveyor Windows image
+  - TOXENV: py39
+  - TOXENV: py310
 
 build: false
 
 install:
-  - py -0  # Show all available versions of Python
-  - py -m pip install --upgrade pip
+  # - py --list
+  # - py -m pip install --upgrade pip
   - py -m pip install tox
 
 test_script:

--- a/src/docs/lang/python.md
+++ b/src/docs/lang/python.md
@@ -38,7 +38,7 @@ environment:
 build: off
 
 install:
-  - py -0  # Show all available Pythons
+  - py -0  # Show all available versions of Python
   - py -m pip install --upgrade pip
   - py -m pip install tox
 
@@ -63,7 +63,7 @@ setup into a `tox.ini` file in your repository root:
 # tox.ini
 
 [tox]
-envlist = py3{5,6,7,8}
+envlist = py3{6,7,8}
 
 [testenv]
 description = Unit tests

--- a/src/docs/lang/python.md
+++ b/src/docs/lang/python.md
@@ -27,18 +27,23 @@ Add an `appveyor.yml` file to your repository root:
 ---
 environment:
   matrix:
-  - TOXENV: py27
-  - TOXENV: py35
-  - TOXENV: py36
+  # - TOXENV: py27  # https://devguide.python.org/devcycle/#end-of-life-branches
+  # - TOXENV: py35
+  - TOXENV: py36    # https://devguide.python.org/#status-of-python-branches
   - TOXENV: py37
+  - TOXENV: py38
+  # - TOXENV: py39    # Not yet present in Appveyor image
+  # - TOXENV: py310    # Not yet present in Appveyor image
 
 build: off
 
 install:
-- pip install tox
+  - py -0  # Show all available Pythons
+  - py -m pip install --upgrade pip
+  - py -m pip install tox
 
 test_script:
-- tox
+  - py -m tox
 ```
 
 ### Test setup
@@ -58,7 +63,7 @@ setup into a `tox.ini` file in your repository root:
 # tox.ini
 
 [tox]
-envlist = py{27,35,36,37}
+envlist = py3{5,6,7,8}
 
 [testenv]
 description = Unit tests

--- a/src/docs/lang/python.md
+++ b/src/docs/lang/python.md
@@ -63,7 +63,7 @@ setup into a `tox.ini` file in your repository root:
 # tox.ini
 
 [tox]
-envlist = py3{6,7,8}
+envlist = py3{6,7,8,9,10}
 
 [testenv]
 description = Unit tests

--- a/src/docs/lang/python.md
+++ b/src/docs/lang/python.md
@@ -35,7 +35,7 @@ environment:
   # - TOXENV: py39    # Not yet present in Appveyor Windows image
   # - TOXENV: py310   # Not yet present in Appveyor Windows image
 
-build: off
+build: false
 
 install:
   - py -0  # Show all available versions of Python

--- a/src/docs/lang/python.md
+++ b/src/docs/lang/python.md
@@ -32,8 +32,8 @@ environment:
   - TOXENV: py36    # https://devguide.python.org/#status-of-python-branches
   - TOXENV: py37
   - TOXENV: py38
-  # - TOXENV: py39    # Not yet present in Appveyor image
-  # - TOXENV: py310   # Not yet present in Appveyor image
+  # - TOXENV: py39    # Not yet present in Appveyor Windows image
+  # - TOXENV: py310   # Not yet present in Appveyor Windows image
 
 build: off
 


### PR DESCRIPTION
Modernize https://www.appveyor.com/docs/lang/python/

The current example installs `tox` on Python 2 which died 672 days ago on 1/1/2020.
The proposed example [uses `py`](https://docs.python.org/3/using/windows.html#python-launcher-for-windows) to install `tox` on Python 3.