### PR TITLE
Add VS 2022 instructions for vcvars32.bat

### DIFF
--- a/src/docs/lang/cpp.md
+++ b/src/docs/lang/cpp.md
@@ -25,6 +25,21 @@ Build configured with makefiles or any scripts directly invoking compiler execut
 
 Run the following in the `appveyor.yml`:
 
+
+### Visual Studio 2022
+
+* For 32-bit target
+
+    ```bat
+    call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat"
+    ```
+
+* For 64-bit target
+
+    ```bat
+    call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+    ```
+
 ### Visual Studio 2019
 
 * For 32-bit target


### PR DESCRIPTION
VS 22 is 64 bit, so in contrary to previous editions it's installed in `C:\Program Files\` (not in `C:\Program Files (x86)\`)

I've tested that it works in https://github.com/dotnet/BenchmarkDotNet/pull/1987