### PR TITLE
Update Windows golang documentation

### DIFF
--- a/src/docs/lang/go.md
+++ b/src/docs/lang/go.md
@@ -36,9 +36,9 @@ clone_folder: c:\gopath\src\github.com\$username\$project
 environment:
   GOPATH: c:\gopath
 
-stack: go 1.10
-
 before_test:
+  - set PATH=C:\go116\bin;%PATH%
+  - set GOROOT=C:\go116
   - go vet ./...
 
 test_script:


### PR DESCRIPTION
As far as I can tell, `stack` is not working as expected on Windows, this adjusts the documentation to some env var changes in order to get the desired go version.