### PR TITLE
(doc) Update installation command

### DIFF
--- a/src/docs/build-configuration.md
+++ b/src/docs/build-configuration.md
@@ -418,7 +418,7 @@ install:
 
 ```yaml
 install:
-  - cinst <package>
+  - choco install <package>
 ```
 
 


### PR DESCRIPTION
Starting with Chocolatey CLI 2.0.0, the cinst shim (along with others) no longer exist:

https://docs.chocolatey.org/en-us/choco/release-notes/#may-31-2023

Instead, the full Chocolatey CLI command should be used.